### PR TITLE
Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,17 @@
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args: ["-l", "90"]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: check-docstring-first
       - id: check-added-large-files
+      - id: check-toml
       - id: check-yaml
         args: ["--unsafe", "mkdocs.yml"]
       - id: check-merge-conflict
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.3
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,10 @@ haystack = [
     "haystack-ai==2.3.1",
     "qdrant-haystack>=5.0.0",
 ]
+
+[tool.ruff]
+line-length = 90
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "Q"]
+ignore = ["E203", "F841", "E501"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 90
-extend-ignore = E203, E704, F841, W503, E501
-
-[isort]
-profile=black


### PR DESCRIPTION
- Ruff is modern and fast; it replaces flake8, isort and black.
- It is configurable via the pyproject.toml file.